### PR TITLE
* Removing GLM tests from build

### DIFF
--- a/cmake/FindGLM.cmake
+++ b/cmake/FindGLM.cmake
@@ -1,1 +1,2 @@
+set(GLM_TEST_ENABLE Off)
 add_subdirectory(${CMAKE_HOME_DIRECTORY}/external/glm ${CMAKE_BINARY_DIR}/glm)


### PR DESCRIPTION
Since this is a git submodule from a stable branch, there is no need for unit tests to be included in the build pipeline, removing them greatly increases cmake generation performance.